### PR TITLE
Add Blossom documentation reader MCP tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,5 @@
 
 This project is a Java implementation of a Model Context Protocol (MCP) server that provides weather information tools. It's built using Spring Boot and Spring AI, following the implementation guide from [MCP Server Java Quickstart](https://modelcontextprotocol.io/quickstart/server#java).
 
+In addition to the original weather endpoints, the server now exposes a tool for reading the official [Blossom](https://github.com/fiatjaf/blossom) (Nostr blob storage) documentation directly from its GitHub repository. You can request the README or any BUD specification (e.g. `BUD-01`, `buds/02.md`) and receive the raw markdown content in the model context.
+

--- a/src/main/java/com/example/weather/WeatherApplication.java
+++ b/src/main/java/com/example/weather/WeatherApplication.java
@@ -1,5 +1,6 @@
 package com.example.weather;
 
+import com.example.weather.service.BlossomDocumentationService;
 import com.example.weather.service.WeatherService;
 
 import org.springframework.boot.SpringApplication;
@@ -16,8 +17,11 @@ public class WeatherApplication {
 	}
 
 	@Bean
-	public ToolCallbackProvider weatherTools(WeatherService weatherService) {
-		return MethodToolCallbackProvider.builder().toolObjects(weatherService).build();
-	}
+        public ToolCallbackProvider weatherTools(WeatherService weatherService,
+                        BlossomDocumentationService blossomDocumentationService) {
+                return MethodToolCallbackProvider.builder()
+                                .toolObjects(weatherService, blossomDocumentationService)
+                                .build();
+        }
 
 }

--- a/src/main/java/com/example/weather/service/BlossomDocumentationService.java
+++ b/src/main/java/com/example/weather/service/BlossomDocumentationService.java
@@ -1,0 +1,79 @@
+package com.example.weather.service;
+
+import java.util.Locale;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.springframework.ai.tool.annotation.Tool;
+import org.springframework.ai.tool.annotation.ToolParam;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+
+@Service
+public class BlossomDocumentationService {
+
+  private static final String BASE_URL = "https://raw.githubusercontent.com/fiatjaf/blossom/master/";
+  private static final Pattern BUD_PATTERN = Pattern.compile("^bud[-_\\s]*(\\d{1,2})$");
+
+  private final RestClient restClient;
+
+  public BlossomDocumentationService() {
+    this.restClient = RestClient.builder()
+        .baseUrl(BASE_URL)
+        .defaultHeader("User-Agent", "MCPBlossomDocReader/1.0 (+https://github.com/fiatjaf/blossom)")
+        .defaultHeader("Accept", "text/plain")
+        .build();
+  }
+
+  @Tool(description = "Read a Blossom (Nostr) documentation file from the official repository")
+  public String readBlossomDocument(
+      @ToolParam(description = "Document identifier (e.g. README, BUD-01, buds/02.md)") String documentId) {
+
+    String path = resolvePath(documentId);
+
+    try {
+      return restClient.get().uri(path).retrieve().body(String.class);
+    } catch (RestClientException ex) {
+      return String.format("Failed to fetch Blossom document '%s': %s", documentId, ex.getMessage());
+    }
+  }
+
+  private String resolvePath(String documentId) {
+    if (documentId == null) {
+      throw new IllegalArgumentException("Document identifier must not be null");
+    }
+
+    String trimmed = documentId.trim();
+    if (trimmed.isEmpty()) {
+      throw new IllegalArgumentException("Document identifier must not be empty");
+    }
+
+    if (trimmed.contains("..")) {
+      throw new IllegalArgumentException("Document identifier must not contain '..'");
+    }
+
+    String lower = trimmed.toLowerCase(Locale.ROOT);
+
+    if ("readme".equals(lower) || "readme.md".equals(lower)) {
+      return "README.md";
+    }
+
+    Matcher matcher = BUD_PATTERN.matcher(lower);
+    if (matcher.matches()) {
+      int number = Integer.parseInt(matcher.group(1));
+      return String.format("buds/%02d.md", number);
+    }
+
+    if (lower.startsWith("buds/")) {
+      String suffix = trimmed.substring("buds/".length()).toLowerCase(Locale.ROOT);
+      if (!suffix.endsWith(".md")) {
+        suffix = suffix + ".md";
+      }
+
+      return "buds/" + suffix;
+    }
+
+    return trimmed;
+  }
+}


### PR DESCRIPTION
## Summary
- add an MCP tool that fetches Blossom documentation from the official GitHub repository
- register the Blossom reader alongside the existing weather tools
- document the new Blossom documentation capability in the README

## Testing
- ./mvnw test

------
https://chatgpt.com/codex/tasks/task_e_68e279bc94388325919b90dde05fdf6a